### PR TITLE
Explicitly require Java 8 compatibility in the library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
     <findbugs.failOnError>true</findbugs.failOnError>
     <java.level>6</java.level>
-    <java.level.test>6</java.level.test>
+    <java.level.test>${java.level}</java.level.test>
   </properties>
 
   <scm>
@@ -60,11 +60,15 @@
                   <ignoredScopes>
                     <ignoredScope>test</ignoredScope>
                   </ignoredScopes>
+                  <excludes>
+                    <!--  findbugs dep managed to provided and optional so is not shipped and missing annotations ok -->
+                    <exclude>com.google.code.findbugs:annotations</exclude>
+                  </excludes>
                 </enforceBytecodeVersion>
                 <requireReleaseDeps>
                   <message>No Snapshots Allowed For Release Versions</message>
                   <onlyWhenRelease>true</onlyWhenRelease>
-                </requireReleaseDeps>
+                </requireReleaseDeps>              
               </rules>
             </configuration>
           </execution>
@@ -76,6 +80,25 @@
             <version>1.0-beta-4</version>
           </dependency>
         </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>1.15</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <id>check</id>
+          </execution>
+        </executions>
+        <configuration>
+          <signature>
+            <groupId>org.codehaus.mojo.signature</groupId>
+            <artifactId>java1${java.level}</artifactId>
+          </signature>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
     <findbugs.failOnError>true</findbugs.failOnError>
-    <java.level>6</java.level>
+    <java.level>8</java.level>
     <java.level.test>${java.level}</java.level.test>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.kohsuke</groupId>
     <artifactId>pom</artifactId>
-    <version>14</version>
+    <version>17</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -15,6 +15,8 @@
   <properties>
     <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
     <findbugs.failOnError>true</findbugs.failOnError>
+    <java.level>6</java.level>
+    <java.level.test>6</java.level.test>
   </properties>
 
   <scm>
@@ -26,6 +28,55 @@
 
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.1</version>
+        <configuration>
+          <source>1.${java.level}</source>
+          <target>1.${java.level}</target>
+          <testSource>1.${java.level.test}</testSource>
+          <testTarget>1.${java.level.test}</testTarget>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.4.1</version>
+        <executions>
+          <execution>
+            <id>display-info</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>display-info</goal>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.0.4,)</version>
+                  <message>Maven 3.0 through 3.0.3 inclusive do not pass correct settings.xml to Maven Release Plugin.</message>
+                </requireMavenVersion>
+                <enforceBytecodeVersion>
+                  <maxJdkVersion>1.${java.level}</maxJdkVersion>
+                  <ignoredScopes>
+                    <ignoredScope>test</ignoredScope>
+                  </ignoredScopes>
+                </enforceBytecodeVersion>
+                <requireReleaseDeps>
+                  <message>No Snapshots Allowed For Release Versions</message>
+                  <onlyWhenRelease>true</onlyWhenRelease>
+                </requireReleaseDeps>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>extra-enforcer-rules</artifactId>
+            <version>1.0-beta-4</version>
+          </dependency>
+        </dependencies>
+      </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.0.2</version>


### PR DESCRIPTION
This is a copy of some bits in Jenkins Plugin Pom. It is a follow-up to the discussion with @jglick in https://github.com/kohsuke/access-modifier/pull/4

- [x] Make Java requirement explicit in Maven Compiler. Stick to Java 6 for a while
- [x] Enable enforcer for dependency checks

@reviewbybees