### PR TITLE
Update WinProcess.java

### DIFF
--- a/src/main/java/org/jvnet/winp/WinProcess.java
+++ b/src/main/java/org/jvnet/winp/WinProcess.java
@@ -24,7 +24,9 @@ public class WinProcess {
     private final int pid;
 
     // these values are lazily obtained, in a pair
-    private String commandline;
+    private String 
+        
+        ;
     private TreeMap<String,String> envVars;
 
     /**
@@ -52,7 +54,7 @@ public class WinProcess {
 
     @Override
     public String toString() {
-        return "WinProcess pid#" + pid + " - " + commandline;
+        return "WinProcess pid#" + pid + " - " + getCommandLine();
     }
     
     /**

--- a/src/main/java/org/jvnet/winp/WinProcess.java
+++ b/src/main/java/org/jvnet/winp/WinProcess.java
@@ -24,9 +24,7 @@ public class WinProcess {
     private final int pid;
 
     // these values are lazily obtained, in a pair
-    private String 
-        
-        ;
+    private String commandline;
     private TreeMap<String,String> envVars;
 
     /**


### PR DESCRIPTION
Using `getCommandLine()` in the `toString()` function to ensure that the `commandline` String variable is set. The `getCommandLine()` function will internally have it parsed if it is currently null.