### PR TITLE
Reenable CI for Windows

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,5 +6,6 @@
 buildPlugin(useContainerAgent: true, configurations: [
   [platform: 'linux', jdk: 21],
   [platform: 'linux', jdk: 17],
+  [platform: 'windows', jdk: 17],
 ])
 


### PR DESCRIPTION
As discussed on https://github.com/jenkinsci/winp/pull/112, this PR will try to enable CI for windows, by using existing jenkins infrastructure (https://ci.jenkins.io/job/jenkinsci-libraries/job/winp/job/master/).

Windows platform was explicitely disabled because native binaries are not available.
This PR will reproduce this, and fix this in a clean way.
Since it's hard to reproduce Jenkins pipeline out of official infra, this PR will serve as a playground.