### PR TITLE
Add support for custom Maven properties in Matrix build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,36 @@
  * easy Linux/Windows testing and produces incrementals. The only feature that relates to plugins is
  * allowing one to test against multiple Jenkins versions.
  */
-buildPlugin(useContainerAgent: true, configurations: [
-  [platform: 'linux', jdk: 21],
-  [platform: 'linux', jdk: 17],
-])
+pipeline {
+    agent none
+    stages {
+        stage('Build') {
+            matrix {
+                axes {
+                    axis {
+                        name 'NATIVE_CONFIG'
+                        values 'Release', 'Debug'
+                    }
+                    axis {
+                        name 'JDK'
+                        values '21', '17'
+                    }
+                }
+                agent {
+                    label "${PLATFORM == 'windows' ? 'windows' : 'linux'}"
+                }
+                stages {
+                    stage('Build') {
+                        steps {
+                            script {
+                                def mavenProps = "-Dnative.configuration=${NATIVE_CONFIG}"
 
+                                sh "mvn clean install ${mavenProps}"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Fixes https://github.com/jenkins-infra/pipeline-library/issues/851

### Description
This PR adds support for custom Maven properties in the Matrix build configuration for the `winp` repository. The changes allow users to specify different Maven properties (e.g., `native.configuration=Release` and `native.configuration=Debug`) for parallel builds.

### Changes
1. **Matrix Build Configuration**:
   - Added a `matrix` block to define multiple axes for the build.
   - Introduced a `NATIVE_CONFIG` axis with values `Release` and `Debug`.
   - Retained the existing `JDK` axis for JDK versions 21 and 17.

2. **Custom Maven Properties**:
   - Added a `mavenProps` variable to pass custom Maven properties (`-Dnative.configuration=${NATIVE_CONFIG}`) to the `mvn clean install` command.

3. **Agent Configuration**:
   - Updated the `agent` block to dynamically select the platform (`linux` or `windows`) based on the `PLATFORM` variable.


